### PR TITLE
[Feat/#36] 로그인, 메인(계좌, 인기클래스), QR 결제 api 연동

### DIFF
--- a/src/apis/apiClient.ts
+++ b/src/apis/apiClient.ts
@@ -2,7 +2,7 @@ import axios, { AxiosInstance } from 'axios';
 import { API_BASE_URL } from './url';
 import { getCookie } from '../utils/cookie';
 import { userApi } from './interfaces/userApi';
-import { LoginType } from '../types/user';
+import { LoginType, PointType } from '../types/user';
 import { AccountType, CheckPwReqType, CheckPwResType } from '../types/account';
 import { accountApi } from './interfaces/accountApi';
 import { hostApi } from './interfaces/hostApi';
@@ -13,8 +13,13 @@ import {
   CreateHostResType,
   HostInfoType,
 } from '../types/host';
+import { LessonDetailType } from '../types/lesson';
+import { transactionApi } from './interfaces/transactionApi';
+import { QrPayReqType } from '../types/transaction';
 
-export class ApiClient implements userApi, accountApi, hostApi, categoryApi {
+export class ApiClient
+  implements userApi, accountApi, hostApi, categoryApi, transactionApi
+{
   private static instance: ApiClient;
   private axiosInstance: AxiosInstance;
 
@@ -127,6 +132,18 @@ export class ApiClient implements userApi, accountApi, hostApi, categoryApi {
   //---------account---------
 
   //---------transaction---------
+  async postQrPay(reqData: QrPayReqType) {
+    const response = await this.axiosInstance.request<
+      BaseResponseType<{
+        transactionId: number;
+      }>
+    >({
+      method: 'post',
+      url: '/transaction/qr',
+      data: reqData,
+    });
+    return response.data;
+  }
 
   //---------category---------
 

--- a/src/apis/apiClient.ts
+++ b/src/apis/apiClient.ts
@@ -1,10 +1,13 @@
 import axios, { AxiosInstance } from 'axios';
 import { API_BASE_URL } from './url';
 import { getCookie } from '../utils/cookie';
+import { userApi } from './interfaces/userApi';
+import { LoginType } from '../types/user';
+import { AccountType } from '../types/account';
+import { accountApi } from './interfaces/accountApi';
+import { hostApi } from './interfaces/hostApi';
 
-export class ApiClient {
-  // implements
-  //   usersApi,
+export class ApiClient implements userApi, accountApi, hostApi {
   private static instance: ApiClient;
   private axiosInstance: AxiosInstance;
 
@@ -12,7 +15,57 @@ export class ApiClient {
     this.axiosInstance = this.createAxiosInstance();
   }
 
-  //---------user---------
+  // ------- user -------
+  async postLogin(password: string) {
+    try {
+      const response = await this.axiosInstance.request<
+        BaseResponseType<LoginType>
+      >({
+        method: 'post',
+        url: '/user/login',
+        data: { password: password },
+      });
+      return response.data;
+    } catch (error: any) {
+      if (axios.isAxiosError(error)) throw error.response?.data;
+      else throw new Error('unexpected error');
+    }
+  }
+
+  async getIsHost() {
+    const response = await this.axiosInstance.request<
+      BaseResponseType<{ isHost: boolean }>
+    >({
+      method: 'get',
+      url: '/user/ishost',
+    });
+    return response.data;
+  }
+
+  // ------- account -------
+  async getAccountList() {
+    const response = await this.axiosInstance.request<
+      BaseResponseType<AccountType[]>
+    >({
+      method: 'get',
+      url: '/account/list',
+    });
+    return response.data;
+  }
+
+  // ------- host -------
+  async postCreateHost(reqData: CreateHostReqType) {
+    const response = await this.axiosInstance.request<
+      BaseResponseType<CreateHostResType>
+    >({
+      method: 'post',
+      url: '/host/create',
+      data: reqData,
+    });
+    return response.data;
+  }
+
+  // ------- mypage -------
 
   // 하나머니 조회
   async getPoint() {
@@ -99,16 +152,6 @@ export class ApiClient {
     const data = await response.json();
     return data;
   }
-
-  //---------users---------
-  // async postLogin(user: LoginReqType) {
-  //   const response = await this.axiosInstance.request<LoginType>({
-  //     method: 'post',
-  //     url: '/users/login',
-  //     data: user,
-  //   });
-  //   return response.data;
-  // }
 
   static getInstance(): ApiClient {
     return this.instance || (this.instance = new this());

--- a/src/apis/apiClient.ts
+++ b/src/apis/apiClient.ts
@@ -3,7 +3,7 @@ import { API_BASE_URL } from './url';
 import { getCookie } from '../utils/cookie';
 import { userApi } from './interfaces/userApi';
 import { LoginType } from '../types/user';
-import { AccountType } from '../types/account';
+import { AccountType, CheckPwReqType, CheckPwResType } from '../types/account';
 import { accountApi } from './interfaces/accountApi';
 import { hostApi } from './interfaces/hostApi';
 import { categoryApi } from './interfaces/categoryApi';
@@ -56,6 +56,17 @@ export class ApiClient implements userApi, accountApi, hostApi, categoryApi {
     >({
       method: 'get',
       url: '/account/list',
+    });
+    return response.data;
+  }
+
+  async getCheckPw(reqData: CheckPwReqType) {
+    const response = await this.axiosInstance.request<
+      BaseResponseType<CheckPwResType>
+    >({
+      method: 'get',
+      url: '/account/pw',
+      data: reqData,
     });
     return response.data;
   }

--- a/src/apis/apiClient.ts
+++ b/src/apis/apiClient.ts
@@ -6,8 +6,15 @@ import { LoginType } from '../types/user';
 import { AccountType } from '../types/account';
 import { accountApi } from './interfaces/accountApi';
 import { hostApi } from './interfaces/hostApi';
+import { categoryApi } from './interfaces/categoryApi';
+import { SearchLessonReqType, SearchLessonResType } from '../types/category';
+import {
+  CreateHostReqType,
+  CreateHostResType,
+  HostInfoType,
+} from '../types/host';
 
-export class ApiClient implements userApi, accountApi, hostApi {
+export class ApiClient implements userApi, accountApi, hostApi, categoryApi {
   private static instance: ApiClient;
   private axiosInstance: AxiosInstance;
 
@@ -54,6 +61,32 @@ export class ApiClient implements userApi, accountApi, hostApi {
   }
 
   // ------- host -------
+  async getSearchLessonAll(reqData: SearchLessonReqType) {
+    const response = await this.axiosInstance.request<
+      BaseResponseType<SearchLessonResType[]>
+    >({
+      method: 'get',
+      url: `/category/all?query=${reqData.query}&sort=${reqData.sort}`,
+    });
+    return response.data;
+  }
+
+  async getHostInfo() {
+    try {
+      const response = await this.axiosInstance.request<
+        BaseResponseType<HostInfoType>
+      >({
+        method: 'get',
+        url: '/host/info',
+      });
+      return response.data;
+    } catch (error: any) {
+      if (axios.isAxiosError(error)) throw error.response?.data;
+      else throw new Error('unexpected error');
+    }
+  }
+
+  // ------- category -------
   async postCreateHost(reqData: CreateHostReqType) {
     const response = await this.axiosInstance.request<
       BaseResponseType<CreateHostResType>

--- a/src/apis/apiClient.ts
+++ b/src/apis/apiClient.ts
@@ -65,11 +65,11 @@ export class ApiClient
     return response.data;
   }
 
-  async getCheckPw(reqData: CheckPwReqType) {
+  async postCheckPw(reqData: CheckPwReqType) {
     const response = await this.axiosInstance.request<
       BaseResponseType<CheckPwResType>
     >({
-      method: 'get',
+      method: 'post',
       url: '/account/pw',
       data: reqData,
     });

--- a/src/apis/interfaces/accountApi.ts
+++ b/src/apis/interfaces/accountApi.ts
@@ -6,7 +6,7 @@ import {
 
 export interface accountApi {
   getAccountList(): Promise<BaseResponseType<AccountType[]>>;
-  getCheckPw(
+  postCheckPw(
     reqData: CheckPwReqType
   ): Promise<BaseResponseType<CheckPwResType>>;
 }

--- a/src/apis/interfaces/accountApi.ts
+++ b/src/apis/interfaces/accountApi.ts
@@ -1,0 +1,12 @@
+import {
+  AccountType,
+  CheckPwReqType,
+  CheckPwResType,
+} from '../../types/account';
+
+export interface accountApi {
+  getAccountList(): Promise<BaseResponseType<AccountType[]>>;
+  getCheckPw(
+    reqData: CheckPwReqType
+  ): Promise<BaseResponseType<CheckPwResType>>;
+}

--- a/src/apis/interfaces/categoryApi.ts
+++ b/src/apis/interfaces/categoryApi.ts
@@ -1,0 +1,7 @@
+import { SearchLessonReqType, SearchLessonResType } from '../../types/category';
+
+export interface categoryApi {
+  getSearchLessonAll(
+    reqData: SearchLessonReqType
+  ): Promise<BaseResponseType<SearchLessonResType[]>>;
+}

--- a/src/apis/interfaces/hostApi.ts
+++ b/src/apis/interfaces/hostApi.ts
@@ -1,0 +1,13 @@
+import {
+  CreateHostReqType,
+  CreateHostResType,
+  HostInfoType,
+} from '../../types/host';
+
+export interface hostApi {
+  postCreateHost(
+    reqType: CreateHostReqType
+  ): Promise<BaseResponseType<CreateHostResType>>;
+
+  getHostInfo(): Promise<BaseResponseType<HostInfoType>>;
+}

--- a/src/apis/interfaces/transactionApi.ts
+++ b/src/apis/interfaces/transactionApi.ts
@@ -1,0 +1,9 @@
+import { QrPayReqType } from '../../types/transaction';
+
+export interface transactionApi {
+  postQrPay(reqData: QrPayReqType): Promise<
+    BaseResponseType<{
+      transactionId: number;
+    }>
+  >;
+}

--- a/src/apis/interfaces/userApi.ts
+++ b/src/apis/interfaces/userApi.ts
@@ -1,7 +1,6 @@
-// export interface usersApi {
-//   postLogin(): Promise<>;
-// }
+import { LoginType } from '../../types/user';
 
 export interface userApi {
-  getPoint(): Promise<BaseResponseType<PointType>>;
+  postLogin(password: string): Promise<BaseResponseType<LoginType>>;
+  getIsHost(): Promise<BaseResponseType<{ isHost: boolean }>>;
 }

--- a/src/components/Atom/InputMoney.tsx
+++ b/src/components/Atom/InputMoney.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useRef, useState } from 'react';
+import { FC, useRef, useState } from 'react';
 import { changeMoneyFormat } from '../../utils/changeMoney';
 
 interface IProps {

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -15,7 +15,7 @@ const Modal = () => {
   };
 
   return (
-    <div className='fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50'>
+    <div className='fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-[100]'>
       <div className='flex flex-col justify-center bg-white rounded-xl w-[277px] h-40 gap-3 z-60'>
         {modalTitle && (
           <p className='text-hanaGreen font-hanaBold text-center text-base'>

--- a/src/components/molecules/PopularLessonItem.tsx
+++ b/src/components/molecules/PopularLessonItem.tsx
@@ -17,7 +17,7 @@ export const PopularLessonItem: FC<IProps> = ({ id, img, title }) => {
       <div className='w-36 rounded-xl overflow-hidden'>
         <img src={img} alt='클래스 사진' className='w-full' />
       </div>
-      <p className='font-hanaRegular text-sm overflow-hidden whitespace-nowrap text-ellipsis break-all'>
+      <p className='font-hanaMedium text-sm overflow-hidden whitespace-nowrap text-ellipsis break-all'>
         {title}
       </p>
     </div>

--- a/src/components/molecules/QR.tsx
+++ b/src/components/molecules/QR.tsx
@@ -5,17 +5,15 @@ import { useTimer } from '../../hooks/useTimer';
 import { VscDebugRestart } from 'react-icons/vsc';
 
 interface IProps {
-  userId: number;
   accountId: number;
-  accountNumber: string;
+
   balance: number;
   onClose: () => void;
 }
 
 export const QR: FC<IProps> = ({
-  userId,
   accountId,
-  accountNumber,
+
   balance,
   onClose,
 }) => {
@@ -26,20 +24,17 @@ export const QR: FC<IProps> = ({
   useEffect(() => {
     setQrValue(
       JSON.stringify({
-        userId,
         accountId,
-        accountNumber,
+
         balance,
       })
     );
-  }, [userId, accountId, accountNumber, balance]);
+  }, [accountId, balance]);
 
   const handleReset = () => {
     setQrValue(
       JSON.stringify({
-        userId,
         accountId,
-        accountNumber,
         balance,
       })
     );

--- a/src/components/organisms/AccountPwKeypad.tsx
+++ b/src/components/organisms/AccountPwKeypad.tsx
@@ -40,6 +40,8 @@ export const AccountPwKeypad: FC<IProps> = ({
       let resultPw: string = '';
       [1, 2, 3, 4].map((num) => (resultPw += password[num]));
       handleClickedPassword(resultPw);
+      setPassword({ 1: -1, 2: -1, 3: -1, 4: -1 });
+      setCurrent(1);
     }
   }, [password]);
 

--- a/src/components/organisms/ChoiceAccount.tsx
+++ b/src/components/organisms/ChoiceAccount.tsx
@@ -1,18 +1,12 @@
 import { FC, useEffect, useState } from 'react';
 import { MdKeyboardArrowDown } from 'react-icons/md';
 import { ModalBottomContainer } from './ModalBottomContainer';
-
-export type AccountType = {
-  accountId: number;
-  accountName: string;
-  accountNumber: string;
-  balance: number;
-};
+import { AccountType } from '../../types/account';
 
 interface IProps {
   accounts: AccountType[];
-  selectedAccount: (accountInfo: AccountType) => void;
   isSelectBtn: boolean;
+  selectedAccount?: (accountInfo: AccountType) => void;
 }
 
 export const ChoiceAccount: FC<IProps> = ({
@@ -30,12 +24,11 @@ export const ChoiceAccount: FC<IProps> = ({
 
   const handleChangedAccount = (account: AccountType) => {
     setSelectedAccountInfo(account);
-    selectedAccount(account);
     setShowModal(false);
   };
 
   useEffect(() => {
-    selectedAccount(accounts[0]);
+    if (selectedAccount) selectedAccount(accounts[0]);
   }, []);
 
   return (

--- a/src/constants/accountSliderOver3Settings.ts
+++ b/src/constants/accountSliderOver3Settings.ts
@@ -1,0 +1,10 @@
+export const Account_Slider_Over3_Settings = {
+  className: 'center',
+  centerMode: true,
+  infinite: true,
+  centerPadding: '15px',
+  slidesToShow: 1,
+  speed: 500,
+  draggable: true,
+  arrows: false,
+};

--- a/src/constants/accountSliderUnder2Settings.ts
+++ b/src/constants/accountSliderUnder2Settings.ts
@@ -1,0 +1,10 @@
+export const Account_Slider_Under2_Settings = {
+  className: 'center',
+  centerMode: true,
+  infinite: false,
+  centerPadding: '15px',
+  slidesToShow: 1,
+  speed: 500,
+  draggable: true,
+  arrows: false,
+};

--- a/src/constants/introCardSliderSettings.ts
+++ b/src/constants/introCardSliderSettings.ts
@@ -1,0 +1,8 @@
+export const IntroCard_Slider_Settings = {
+  dots: true,
+  slidesToShow: 1,
+  speed: 500,
+  draggable: true,
+  arrows: false,
+  infinite: false,
+};

--- a/src/index.css
+++ b/src/index.css
@@ -30,10 +30,6 @@
   font-style: normal;
 }
 
-.scroll::-webkit-scrollbar {
-  display: none;
-}
-
 .one-item .slick-list {
   width: 390px;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -33,6 +33,11 @@
 .scroll::-webkit-scrollbar {
   display: none;
 }
+
+.one-item .slick-list {
+  width: 390px;
+}
+
 .custom-slider .slick-slide > div {
   padding: 0 5px;
 }

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from 'react';
 import { PasswordKeypad } from '../../components/molecules/PasswordKeypad';
 import { useNavigate } from 'react-router-dom';
+import { useMutation } from '@tanstack/react-query';
+import { ApiClient } from '../../apis/apiClient';
+import { setCookie } from '../../utils/cookie';
+import { useModal } from '../../context/ModalContext';
 
 type PasswordType = {
   [number: number]: number;
@@ -17,6 +21,38 @@ export const Login = () => {
     6: -1,
   });
   const [current, setCurrent] = useState<number>(1);
+  const [isFalse, setIsFalse] = useState<boolean>(false);
+
+  const { mutate: login } = useMutation({
+    mutationFn: (password: string) => {
+      const res = ApiClient.getInstance().postLogin(password);
+      return res;
+    },
+    onSuccess: (data) => {
+      if (data.isSuccess) {
+        if (data.data?.jwt && data.data.userName) {
+          setCookie('token', data.data.jwt);
+          setCookie('username', data.data.userName);
+          navigate('/');
+        }
+      }
+    },
+    onError: (error: ErrorType) => {
+      if (!error.isSuccess) {
+        // openModal('비밀번호를 다시 입력하세요.', closeModal);
+        setIsFalse(true);
+        setPassword({
+          1: -1,
+          2: -1,
+          3: -1,
+          4: -1,
+          5: -1,
+          6: -1,
+        });
+        setCurrent(1);
+      }
+    },
+  });
 
   const onChangePassword = (number: number) => {
     if (current > 6) return;
@@ -33,9 +69,7 @@ export const Login = () => {
   const sendLogin = () => {
     let resultPw = '';
     [1, 2, 3, 4, 5, 6].map((num) => (resultPw += password[num]));
-    console.log('비밀번호>>', resultPw);
-    console.log('로그인');
-    navigate('/');
+    login(resultPw);
   };
 
   useEffect(() => {
@@ -45,7 +79,14 @@ export const Login = () => {
   return (
     <div className='bg-[#373A4D] h-screen pt-40 flex flex-col items-center'>
       <h3 className='text-white font-hanaMedium text-xl'>간편비밀번호 입력</h3>
-      <div className='flex justify-center items-center gap-5 mt-8'>
+      {isFalse && (
+        <p className='font-hanaLight text-white/50 text-sm mt-1'>
+          비밀번호를 다시 입력하세요.
+        </p>
+      )}
+      <div
+        className={`flex justify-center items-center gap-5 ${isFalse ? 'mt-4' : 'mt-10'}`}
+      >
         {[1, 2, 3, 4, 5, 6].map((num: number, index) => (
           <div
             key={index}

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -39,7 +39,6 @@ export const Login = () => {
     },
     onError: (error: ErrorType) => {
       if (!error.isSuccess) {
-        // openModal('비밀번호를 다시 입력하세요.', closeModal);
         setIsFalse(true);
         setPassword({
           1: -1,

--- a/src/pages/main/HanaFunMain.tsx
+++ b/src/pages/main/HanaFunMain.tsx
@@ -234,7 +234,7 @@ export const HanaFunMain = () => {
 
         <div className='mt-8'>
           <h1 className='font-hanaBold text-xl mb-1.5'>인기클래스</h1>
-          <div className='flex gap-2.5 overflow-x-auto scroll'>
+          <div className='flex gap-2.5 overflow-x-scroll scrollbar-hide'>
             {popularLessonList?.data &&
               popularLessonList.data.map((item, index) => (
                 <PopularLessonItem

--- a/src/pages/main/HanaFunMain.tsx
+++ b/src/pages/main/HanaFunMain.tsx
@@ -60,9 +60,13 @@ export const HanaFunMain = () => {
     staleTime: 10000,
   });
 
-  const { mutate: checkPw } = useMutation({
+  const {
+    mutate: checkPw,
+    isPending: isCheckPwPeding,
+    isSuccess: isCheckPwSuccess,
+  } = useMutation({
     mutationFn: (reqData: CheckPwReqType) => {
-      const res = ApiClient.getInstance().getCheckPw(reqData);
+      const res = ApiClient.getInstance().postCheckPw(reqData);
       return res;
     },
     onSuccess: (data) => {
@@ -75,7 +79,6 @@ export const HanaFunMain = () => {
   });
 
   const sendAccountPassword = (password: string) => {
-    console.log('dd>', selectedAccount.accountId, password);
     checkPw({
       accountId: selectedAccount.accountId,
       password: password,

--- a/src/pages/main/HanaFunMain.tsx
+++ b/src/pages/main/HanaFunMain.tsx
@@ -11,42 +11,19 @@ import { PopularLessonItem } from '../../components/molecules/PopularLessonItem'
 import { AccountPwKeypad } from '../../components/organisms/AccountPwKeypad';
 import { Slide } from '../../components/organisms/Slide';
 import { QR } from '../../components/molecules/QR';
-import { AccountType } from '../../components/organisms/ChoiceAccount';
 import { RiQrScan2Line } from 'react-icons/ri';
-import { Lessondata } from '../search/LessonSearch';
-import { getCookie, setCookie } from '../../utils/cookie';
+import { getCookie } from '../../utils/cookie';
 import { useNavigate } from 'react-router-dom';
 import { QRScanner } from '../../components/molecules/QRScanner';
-
-export const userDummyData = {
-  userId: 1,
-  name: '오감자',
-  accounts: [
-    {
-      accountId: 1,
-      accountName: '영하나플러스통장',
-      accountNumber: '748-911331-11111',
-      balance: 100000,
-    },
-    {
-      accountId: 2,
-      accountName: '영둘플러스통장',
-      accountNumber: '748-911331-22222',
-      balance: 200000,
-    },
-    {
-      accountId: 3,
-      accountName: '영셋플러스통장',
-      accountNumber: '748-911331-33333',
-      balance: 300000,
-    },
-  ],
-};
+import { useQuery } from '@tanstack/react-query';
+import { ApiClient } from '../../apis/apiClient';
+import { Loading } from '../Loading';
+import { AccountType } from '../../types/account';
 
 const accountSliderSettings = {
   className: 'center',
   centerMode: true,
-  infinite: true,
+  infinite: false,
   centerPadding: '15px',
   slidesToShow: 1,
   speed: 500,
@@ -69,17 +46,33 @@ export const HanaFunMain = () => {
   const [showQr, setShowQr] = useState<boolean>(false);
   const [isScan, setIsScan] = useState(false);
   const [active, setActive] = useState<number | null>(null);
-
-  setCookie(
-    'token',
-    'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiLsnbTrr7zsp4AiLCJ1c2VySWQiOjEsImlhdCI6MTcxOTkwNjc5OCwiZXhwIjoxNzE5OTEwMzk4fQ.XrNBs6nWmQanGcsMQZFNVHT-xPmvvOPb3icd1naFjrE'
-  );
-
   const [selectedAccount, setSelectedAccount] = useState<AccountType>({
     accountId: -1,
     accountName: '',
     accountNumber: '',
     balance: 0,
+  });
+  const username = getCookie('username');
+  const token = getCookie('token');
+
+  const { isLoading: isGetAccountList, data: accountList } = useQuery({
+    queryKey: [token, 'accountList'],
+    queryFn: () => {
+      const res = ApiClient.getInstance().getAccountList();
+      return res;
+    },
+  });
+
+  const { isLoading: isGetPopularLesson, data: popularLessonList } = useQuery({
+    queryKey: ['popularLessonList'],
+    queryFn: () => {
+      const res = ApiClient.getInstance().getSearchLessonAll({
+        query: '',
+        sort: 'popular',
+      });
+      return res;
+    },
+    staleTime: 10000,
   });
 
   const sendAccountPassword = (password: string) => {
@@ -104,10 +97,10 @@ export const HanaFunMain = () => {
     setActive(active === index ? null : index);
   };
 
-  // useEffect(() => {
-  //   const token = getCookie('token');
-  //   if (!token) navigate('/hana');
-  // }, []);
+  useEffect(() => {
+    const token = getCookie('token');
+    if (!token) navigate('/hana');
+  }, []);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -123,6 +116,8 @@ export const HanaFunMain = () => {
     };
   }, [active]);
 
+  if (isGetAccountList && isGetPopularLesson) return <Loading />;
+
   return (
     <>
       {isScan && <QRScanner onClose={() => setIsScan(false)} />}
@@ -137,9 +132,7 @@ export const HanaFunMain = () => {
       )}
       {showQr && (
         <QR
-          userId={userDummyData.userId}
           accountId={selectedAccount.accountId}
-          accountNumber={selectedAccount.accountNumber}
           balance={selectedAccount.balance}
           onClose={() => setShowQr(false)}
         />
@@ -147,7 +140,7 @@ export const HanaFunMain = () => {
       <div className='pt-8 px-5 mb-32'>
         <div className='flex items-center justify-between'>
           <p className='font-hanaBold text-xl text-hanaGreen'>
-            {userDummyData.name} <span className='text-black'>님</span>
+            {username} <span className='text-black'>님</span>
           </p>
           <button
             className='flex justify-center items-center font-hanaMedium gap-1.5 text-base text-black/80'
@@ -159,40 +152,44 @@ export const HanaFunMain = () => {
         </div>
 
         <div className='mt-6 flex items-center justify-center'>
-          <Slide settings={accountSliderSettings} cssName='custom-slider'>
-            {userDummyData.accounts.map((account, index) => (
-              <div
-                key={account.accountId}
-                className='relative w-full bg-white rounded-2xl py-5 px-7 font-hanaBold'
-              >
-                <div className='lesson-card flex items-center justify-between'>
-                  <span className='text-black text-lg'>
-                    {account.accountName}
-                  </span>
-                  <GoKebabHorizontal
-                    color='#B5B5B5'
-                    size={16}
-                    className='rotate-90 cursor-pointer'
-                    onClick={() => clickedAccount(account, index)}
-                  />
-                  {active === index && (
-                    <div className='absolute right-0 mr-11'>
-                      <DropdownSingle
-                        image='/images/qr.svg'
-                        text='QR생성'
-                        handleClick={() => setShowKeypad(true)}
-                      />
-                    </div>
-                  )}
+          <Slide
+            settings={accountSliderSettings}
+            cssName={`custom-slider ${accountList?.data?.length === 1 && 'one-item'}`}
+          >
+            {accountList?.data &&
+              accountList.data.map((account, index) => (
+                <div
+                  key={account.accountId}
+                  className={`relative ${accountList.data?.length === 1 ? 'w-[351px]' : 'w-full'} bg-white rounded-2xl py-5 px-7 font-hanaBold`}
+                >
+                  <div className='lesson-card flex items-center justify-between'>
+                    <span className='text-black text-lg'>
+                      {account.accountName}
+                    </span>
+                    <GoKebabHorizontal
+                      color='#B5B5B5'
+                      size={16}
+                      className='rotate-90 cursor-pointer'
+                      onClick={() => clickedAccount(account, index)}
+                    />
+                    {active === index && (
+                      <div className='absolute right-0 mr-11'>
+                        <DropdownSingle
+                          image='/images/qr.svg'
+                          text='QR생성'
+                          handleClick={() => setShowKeypad(true)}
+                        />
+                      </div>
+                    )}
+                  </div>
+                  <p className='text-hanaSilver text-sm mt-0.5'>
+                    {account.accountNumber}
+                  </p>
+                  <p className='text-black text-lg flex justify-end mt-4'>
+                    {account.balance.toLocaleString()}원
+                  </p>
                 </div>
-                <p className='text-hanaSilver text-sm mt-0.5'>
-                  {account.accountNumber}
-                </p>
-                <p className='text-black text-lg flex justify-end mt-4'>
-                  {account.balance.toLocaleString()}원
-                </p>
-              </div>
-            ))}
+              ))}
           </Slide>
         </div>
 
@@ -235,14 +232,15 @@ export const HanaFunMain = () => {
         <div className='mt-8'>
           <h1 className='font-hanaBold text-xl mb-1.5'>인기클래스</h1>
           <div className='flex gap-2.5 overflow-x-auto scroll'>
-            {Lessondata.map((item, index) => (
-              <PopularLessonItem
-                key={index}
-                id={item.lesson_id}
-                img={item.image}
-                title={item.title}
-              />
-            ))}
+            {popularLessonList?.data &&
+              popularLessonList.data.map((item, index) => (
+                <PopularLessonItem
+                  key={index}
+                  id={item.lesson_id}
+                  img={item.image}
+                  title={item.title}
+                />
+              ))}
           </div>
         </div>
       </div>

--- a/src/pages/main/QRPay.tsx
+++ b/src/pages/main/QRPay.tsx
@@ -3,41 +3,31 @@ import { Topbar } from '../../components/common/Topbar';
 import { qrUserInfo } from '../../components/molecules/QRScanner';
 import { Button } from '../../components/common/Button';
 import { useEffect, useState } from 'react';
-import {
-  AccountType,
-  ChoiceAccount,
-} from '../../components/organisms/ChoiceAccount';
-import { userDummyData } from './HanaFunMain';
+import { ChoiceAccount } from '../../components/organisms/ChoiceAccount';
 import { InputMoney } from '../../components/Atom/InputMoney';
 import { ChoiceInput } from '../../components/molecules/ChoiceInput';
 import { CompleteSend } from '../../components/organisms/CompleteSend';
 import { useQuery } from '@tanstack/react-query';
 import { ApiClient } from '../../apis/apiClient';
 import { ModalBottomContainer } from '../../components/organisms/ModalBottomContainer';
+import { useModal } from '../../context/ModalContext';
+import { LessonType } from '../../types/lesson';
+import { Loading } from '../Loading';
 
 export const QRPay = () => {
   const location = useLocation();
   const navigate = useNavigate();
+  const { openModal, closeModal } = useModal();
 
   const userInfo: qrUserInfo = location.state;
   const [isBtnActive, setIsBtnActive] = useState<boolean>(false);
-  const selectedAccount = (account: AccountType) => {}; // 호스트 계좌 ID
   const [showLessonList, setShowLessonList] = useState<boolean>(false);
-  const [selectedLesson, setSelectedLesson] =
-    useState<HostLessonInfoType | null>(null);
+  const [selectedLesson, setSelectedLesson] = useState<LessonType | null>(null);
   const [showLessonDateList, setShowLessonDateList] = useState<boolean>(false);
   const [selectedLessonDate, setSelectedLessonDate] =
     useState<HostLessonDetailType | null>(null);
   const [money, setMoney] = useState<number>(-1);
   const [isSend, setIsSend] = useState<boolean>(false);
-
-  const { data: hostLessons } = useQuery({
-    queryKey: ['hostLessons'],
-    queryFn: async () => {
-      const response = await ApiClient.getHostLesson();
-      return response;
-    },
-  });
 
   const { data: hostLessonDetail } = useQuery({
     queryKey: ['hostLessonDetail'],
@@ -47,7 +37,7 @@ export const QRPay = () => {
     },
   });
 
-  const onChangeLesson = (lesson: HostLessonInfoType) => {
+  const onChangeLesson = (lesson: LessonType) => {
     setSelectedLesson(lesson);
     setShowLessonList(false);
     checkValid();
@@ -74,22 +64,42 @@ export const QRPay = () => {
     else setIsBtnActive(false);
   };
   const handleSendPayment = () => {
-    console.log('게스트ID>>', userInfo.userId);
     console.log('출금계좌ID>>', userInfo.accountId);
     console.log('입금계좌ID>>', 1);
-    console.log('클래스 ID>>', selectedLesson?.lesson_id);
+    console.log('클래스 ID>>', selectedLesson?.lessonId);
     console.log('클래스일정ID>>', selectedLessonDate?.lessondate_id);
     console.log('지불금액>>', money);
-    setIsSend(true);
+    // setIsSend(true);
   };
 
   useEffect(() => {
     checkValid();
-  }, [money, selectedLesson?.lesson_id, selectedLessonDate?.lessondate_id]);
+  }, [money, selectedLesson?.lessonId, selectedLessonDate?.lessondate_id]);
+
+  const {
+    data: hostInfo,
+    isError: getHostInfoError,
+    isLoading: getHostInfoLoading,
+  } = useQuery({
+    queryKey: ['hostLessons'],
+    queryFn: async () => {
+      const response = await ApiClient.getInstance().getHostInfo();
+      return response;
+    },
+  });
+
+  if (getHostInfoLoading) {
+    return <Loading />;
+  }
+
+  if (getHostInfoError) {
+    openModal('호스트가 아닙니다. 호스트 등록을 먼저 해주세요.', closeModal);
+    navigate('/');
+  }
 
   return (
     <>
-      {hostLessons && showLessonList && (
+      {hostInfo && hostInfo.data && showLessonList && (
         <ModalBottomContainer
           color='#FFFFFF'
           onClose={() => setShowLessonList(false)}
@@ -98,7 +108,7 @@ export const QRPay = () => {
           <div className='w-full'>
             <hr />
             <div className='max-h-60 overflow-y-auto scrollbar-hide px-6 py-2'>
-              {hostLessons.map((lesson, idx) => (
+              {hostInfo.data?.lessonList.map((lesson, idx) => (
                 <div key={idx}>
                   <p
                     className='py-2 font-hanaRegular text-base cursor-pointer pl-1'
@@ -106,7 +116,7 @@ export const QRPay = () => {
                   >
                     {lesson.title}
                   </p>
-                  {idx !== hostLessons.length - 1 && <hr />}
+                  {idx + 1 !== hostInfo.data?.lessonList.length && <hr />}
                 </div>
               ))}
             </div>
@@ -138,48 +148,53 @@ export const QRPay = () => {
         </ModalBottomContainer>
       )}
       <Topbar title='QR결제' onClick={() => navigate('/')} />
-      {!isSend ? (
+      {hostInfo && (
         <>
-          <div className='pt-5 mb-11'>
-            <ChoiceAccount
-              accounts={[userDummyData.accounts[0]]}
-              selectedAccount={selectedAccount}
-              isSelectBtn={false}
-            />
-          </div>
-          <div className='px-5 mb-12'>
-            <h3 className='font-hanaBold mb-2'>클래스</h3>
-            <ChoiceInput
-              isChoice={!!selectedLesson}
-              content={
-                selectedLesson ? selectedLesson.title : '클래스를 선택해주세요.'
-              }
-              openModal={() => setShowLessonList(true)}
-            />
-            {selectedLesson && (
-              <>
-                <h3 className='font-hanaBold mt-6 mb-2'>클래스 일정</h3>
-                <ChoiceInput
-                  isChoice={!!selectedLessonDate}
-                  content={
-                    selectedLessonDate
-                      ? selectedLessonDate.date
-                      : '클래스 일정을 선택해주세요.'
-                  }
-                  openModal={() => setShowLessonDateList(true)}
+          {!isSend ? (
+            <>
+              <div className='pt-5 mb-11'>
+                <ChoiceAccount
+                  accounts={[hostInfo?.data?.account]}
+                  isSelectBtn={false}
                 />
-              </>
-            )}
-          </div>
+              </div>
+              <div className='px-5 mb-12'>
+                <h3 className='font-hanaBold mb-2'>클래스</h3>
+                <ChoiceInput
+                  isChoice={!!selectedLesson}
+                  content={
+                    selectedLesson
+                      ? selectedLesson.title
+                      : '클래스를 선택해주세요.'
+                  }
+                  openModal={() => setShowLessonList(true)}
+                />
+                {selectedLesson && (
+                  <>
+                    <h3 className='font-hanaBold mt-6 mb-2'>클래스 일정</h3>
+                    <ChoiceInput
+                      isChoice={!!selectedLessonDate}
+                      content={
+                        selectedLessonDate
+                          ? selectedLessonDate.date
+                          : '클래스 일정을 선택해주세요.'
+                      }
+                      openModal={() => setShowLessonDateList(true)}
+                    />
+                  </>
+                )}
+              </div>
 
-          <InputMoney
-            maxMoney={userInfo.balance}
-            isChangeMoney={true}
-            changeMoney={onChangeMoney}
-          />
+              <InputMoney
+                maxMoney={userInfo.balance}
+                isChangeMoney={true}
+                changeMoney={onChangeMoney}
+              />
+            </>
+          ) : (
+            <CompleteSend title2='결제 성공' />
+          )}
         </>
-      ) : (
-        <CompleteSend title2='결제 성공' />
       )}
       <Button
         message={!isSend ? '결제' : '완료'}

--- a/src/pages/main/QRPay.tsx
+++ b/src/pages/main/QRPay.tsx
@@ -82,7 +82,7 @@ export const QRPay = () => {
   };
 
   useEffect(() => {
-    checkValid();
+    if (!getHostInfoLoading && !getHostInfoError) checkValid();
   }, [money, selectedLesson?.lessonId, selectedLessonDate?.lessondateId]);
 
   const {
@@ -95,6 +95,7 @@ export const QRPay = () => {
       const response = await ApiClient.getInstance().getHostInfo();
       return response;
     },
+    retry: 1,
   });
 
   const { data: hostLessonDetail } = useQuery({

--- a/src/pages/openLesson/RegisterHost.tsx
+++ b/src/pages/openLesson/RegisterHost.tsx
@@ -1,13 +1,10 @@
 import { useNavigate } from 'react-router-dom';
 import { Topbar } from '../../components/common/Topbar';
 import { Button } from '../../components/common/Button';
-import { userDummyData } from '../main/HanaFunMain';
-import {
-  AccountType,
-  ChoiceAccount,
-} from '../../components/organisms/ChoiceAccount';
+import { ChoiceAccount } from '../../components/organisms/ChoiceAccount';
 import { useRef, useState } from 'react';
 import { CompleteSend } from '../../components/organisms/CompleteSend';
+import { AccountType } from '../../types/account';
 
 export const RegisterHost = () => {
   const navigate = useNavigate();
@@ -39,11 +36,11 @@ export const RegisterHost = () => {
           </div>
           <div className='mt-5'>
             <h2 className='font-hanaBold text-xl mb-2 px-5'>입금계좌</h2>
-            <ChoiceAccount
+            {/* <ChoiceAccount
               accounts={userDummyData.accounts}
               selectedAccount={selectedAccountId}
               isSelectBtn={true}
-            />
+            /> */}
           </div>
           <div className='mt-5 px-5'>
             <h2 className='font-hanaBold text-xl mb-2'>소개</h2>

--- a/src/pages/search/PayLesson.tsx
+++ b/src/pages/search/PayLesson.tsx
@@ -1,11 +1,7 @@
 import { useRef, useState } from 'react';
 import { Button } from '../../components/common/Button';
 import { Topbar } from '../../components/common/Topbar';
-import { userDummyData } from '../main/HanaFunMain';
-import {
-  AccountType,
-  ChoiceAccount,
-} from '../../components/organisms/ChoiceAccount';
+import { ChoiceAccount } from '../../components/organisms/ChoiceAccount';
 import { InputMoney } from '../../components/Atom/InputMoney';
 import { FaRegCheckCircle } from 'react-icons/fa';
 import { changeMoneyFormat } from '../../utils/changeMoney';
@@ -132,11 +128,11 @@ export const PayLesson = () => {
       {!isSend ? (
         <div className='pt-5 mb-28'>
           <div className='mt-6'>
-            <ChoiceAccount
+            {/* <ChoiceAccount
               accounts={userDummyData.accounts}
               selectedAccount={selectedAccount}
               isSelectBtn={true}
-            />
+            /> */}
           </div>
           <InputMoney maxMoney={state.payment} isChangeMoney={false} />
           <div

--- a/src/types/account.d.ts
+++ b/src/types/account.d.ts
@@ -1,0 +1,15 @@
+export type AccountType = {
+  accountId: number;
+  accountName: string;
+  accountNumber: string;
+  balance: number;
+};
+
+export type CheckPwReqType = {
+  accountId: number;
+  password: string;
+};
+
+export type CheckPwResType = {
+  check: boolean;
+};

--- a/src/types/category.d.ts
+++ b/src/types/category.d.ts
@@ -1,0 +1,12 @@
+export type SearchLessonReqType = {
+  query: string;
+  sort: string;
+};
+
+export type SearchLessonResType = {
+  lesson_id: number;
+  image: string;
+  title: string;
+  price: number;
+  host_name: string;
+};

--- a/src/types/error.d.ts
+++ b/src/types/error.d.ts
@@ -1,0 +1,4 @@
+type ErrorType = {
+  isSuccess: boolean;
+  message: string;
+};

--- a/src/types/host.d.ts
+++ b/src/types/host.d.ts
@@ -1,0 +1,16 @@
+import { AccountType } from '../components/organisms/ChoiceAccount';
+import { LessonType } from './lesson';
+
+type CreateHostReqType = {
+  accountId: number;
+  introduction: string;
+};
+
+type CreateHostResType = {
+  hostId: number;
+};
+
+type HostInfoType = {
+  account: AccountType;
+  lessonList: LessonType[];
+};

--- a/src/types/host.d.ts
+++ b/src/types/host.d.ts
@@ -1,4 +1,4 @@
-import { AccountType } from '../components/organisms/ChoiceAccount';
+import { AccountType } from './account';
 import { LessonType } from './lesson';
 
 type CreateHostReqType = {

--- a/src/types/lesson.d.ts
+++ b/src/types/lesson.d.ts
@@ -1,3 +1,8 @@
+export type LessonType = {
+  lessonId: number;
+  title: string;
+};
+
 interface LessonDetailType {
   lesson_id: number;
   image: string;

--- a/src/types/reservation.d.ts
+++ b/src/types/reservation.d.ts
@@ -5,8 +5,8 @@ interface HostLessonType {
 }
 
 interface HostLessonDetailType {
-  lessondate_id: number;
+  lessondateId: number;
   date: string;
-  lesson_id: number;
+  lessonId: number;
   title: string;
 }

--- a/src/types/transaction.d.ts
+++ b/src/types/transaction.d.ts
@@ -1,0 +1,7 @@
+export type QrPayReqType = {
+  withdrawId: number;
+  depositId: number;
+  lessonId: number;
+  lessondateId: number;
+  payment: number;
+};

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -1,3 +1,8 @@
+export type LoginType = {
+  jwt: string;
+  userName: string;
+};
+
 interface PointType {
   point: number;
 }


### PR DESCRIPTION
## 📢 기능 설명 
### 로그인 api 연동
- 비밀번호 틀린 경우
<img width="333" alt="스크린샷 2024-07-03 오전 9 54 57" src="https://github.com/HanaFun/HanaFun_FE/assets/79428205/116b74a9-b4d2-43cc-98fb-2e10c25af752">

- 로그인 한 후(토큰, 이름 저장)
<img width="339" alt="스크린샷 2024-07-03 오전 9 55 19" src="https://github.com/HanaFun/HanaFun_FE/assets/79428205/9fa2b6ae-0b16-4f35-9fb0-40e80b5c0aee">
<img width="232" alt="스크린샷 2024-07-03 오전 9 55 39" src="https://github.com/HanaFun/HanaFun_FE/assets/79428205/89b74c91-a7ff-45f9-a2ab-a7c0d5c1f1c5">

### 메인 - 계좌 목록 api 연동
<img width="360" alt="스크린샷 2024-07-03 오전 9 56 06" src="https://github.com/HanaFun/HanaFun_FE/assets/79428205/f5a8f599-e744-4dfc-9d7a-746f6dfab1c7">

### 메인 - 인기클래스 목록 api 연동
<img width="328" alt="스크린샷 2024-07-03 오전 9 56 31" src="https://github.com/HanaFun/HanaFun_FE/assets/79428205/0e70653d-f31d-41e6-a891-318d309c9d16">


### 계좌 비밀번호 api 연동
- 계좌 비밀번호 틀린 경우
<img width="334" alt="스크린샷 2024-07-03 오전 9 56 56" src="https://github.com/HanaFun/HanaFun_FE/assets/79428205/ffef4b8d-5cd0-4e31-929a-153689b98a8a">
- 계좌 비밀번호 일치하는 경우
<img width="331" alt="스크린샷 2024-07-03 오전 9 57 19" src="https://github.com/HanaFun/HanaFun_FE/assets/79428205/8936048d-c49a-4669-94c7-8e8c3c2afafd">

### QR 결제 api 연동
- 클래스 목록 api
<img width="335" alt="스크린샷 2024-07-03 오전 9 57 59" src="https://github.com/HanaFun/HanaFun_FE/assets/79428205/bc9ad741-712a-4c9a-8b87-203aeabac579">

- 클래스 일정 목록 api
<img width="338" alt="스크린샷 2024-07-03 오전 9 58 10" src="https://github.com/HanaFun/HanaFun_FE/assets/79428205/23a10de3-4669-4d13-9f90-d5e0636f6070">

- qr 결제 api
<img width="337" alt="스크린샷 2024-07-03 오전 10 01 27" src="https://github.com/HanaFun/HanaFun_FE/assets/79428205/2ea700e2-2abb-445d-97bf-106c19941774">


<br>

## 연결된 issue
연결된 Issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #36 
<br>